### PR TITLE
fix: X2C.inflate attach wrong

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,9 +31,9 @@ dependencies {
 
     implementation project(':app-module')
 
-//        annotationProcessor project(':x2c-apt')
-//        implementation project(':x2c-lib')
+    annotationProcessor project(':x2c-apt')
+    implementation project(':x2c-lib')
 
-    annotationProcessor 'com.zhangyue.we:x2c-apt:1.1.1'
-    implementation 'com.zhangyue.we:x2c-lib:1.0.6'
+    // annotationProcessor 'com.zhangyue.we:x2c-apt:1.1.1'
+    // implementation 'com.zhangyue.we:x2c-lib:1.0.6'
 }

--- a/app/src/main/java/com/zhangyue/we/x2c/demo/MyFragment.java
+++ b/app/src/main/java/com/zhangyue/we/x2c/demo/MyFragment.java
@@ -21,7 +21,7 @@ public class MyFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
-        return X2C.inflate(inflater.getContext(), R.layout.fragmetn_layout, null);
+        return X2C.inflate(inflater.getContext(), R.layout.fragmetn_layout, container, false);
     }
 
 }

--- a/x2c-lib/src/main/java/com/zhangyue/we/x2c/X2C.java
+++ b/x2c-lib/src/main/java/com/zhangyue/we/x2c/X2C.java
@@ -39,21 +39,26 @@ public class X2C {
      * @param layoutId layout的资源id
      */
     public static View inflate(Context context, int layoutId, ViewGroup parent) {
-        return inflate(context, layoutId, parent, true);
+        return inflate(context, layoutId, parent, parent != null);
     }
 
     public static View inflate(Context context, int layoutId, ViewGroup parent, boolean attach) {
-        if (context == null) {
-            throw new IllegalArgumentException("Context must not be null");
-        }
-        View view = getView(context, layoutId);
+        return inflate(LayoutInflater.from(context), layoutId, parent, attach);
+    }
+
+    public static View inflate(LayoutInflater inflater, int layoutId, ViewGroup parent) {
+        return inflate(inflater, layoutId, parent, parent != null);
+    }
+
+    public static View inflate(LayoutInflater inflater, int layoutId, ViewGroup parent, boolean attach) {
+        View view = getView(inflater.getContext(), layoutId);
         if (view != null) {
-            if (parent != null) {
+            if (parent != null && attach) {
                 parent.addView(view);
             }
             return view;
         } else {
-            return LayoutInflater.from(context).inflate(layoutId, parent, attach);
+            return inflater.inflate(layoutId, parent, attach);
         }
     }
 


### PR DESCRIPTION
原来的 X2C.inflate 中 attach 参数判断错误。

```java
public static View inflate(Context context, int layoutId, ViewGroup parent) {
    //## 最后一个参数 attach 应为 parent != null
    return inflate(context, layoutId, parent, true);
}

public static View inflate(Context context, int layoutId, ViewGroup parent, boolean attach) {
    if (context == null) {
        throw new IllegalArgumentException("Context must not be null");
    }
    View view = getView(context, layoutId);
    if (view != null) {
        //## 这里需要判断 attach 是否为 true
        if (parent != null) {
            parent.addView(view);
        }
        return view;
    } else {
        return LayoutInflater.from(context).inflate(layoutId, parent, attach);
    }
}
```
