### PR TITLE
Fix: After translation Some views import wrong

### DIFF
--- a/x2c-apt/src/main/java/com/zhangyue/we/view/View.java
+++ b/x2c-apt/src/main/java/com/zhangyue/we/view/View.java
@@ -112,6 +112,12 @@ public class View implements ITranslator {
                 case "fragment":
                     name = "android.widget.FrameLayout";
                     break;
+                case "TextureView":
+                    name = "android.view.TextureView";
+                    break;
+                case "SurfaceView":
+                    name = "android.view.SurfaceView";
+                    break;
                 default:
                     name = "android.widget." + name;
                     break;


### PR DESCRIPTION
Layout中的SurfaceView和TextureView 编译过后添加的import包错误，正确的应该是import android.view.SurfaceView;和 import android.view.TextureView，而X2C编译出的是import android.widget.*****;
错误log如下：
>  错误: 找不到符号
> import android.widget.TextureView;
>                      ^
>   符号:   类 TextureView
>   位置: 程序包 android.widget