### PR TITLE
修复生成java错误 : cannot convert from double to float

### DIFF
--- a/x2c-apt/src/main/java/com/zhangyue/we/view/View.java
+++ b/x2c-apt/src/main/java/com/zhangyue/we/view/View.java
@@ -677,6 +677,10 @@ public class View implements ITranslator {
             dim = value.substring(0, value.indexOf("p"));
         }
 
+        if (dim.contains(".")) {
+            dim = dim + "f";
+        }
+
         return String.format("(int)(TypedValue.applyDimension(%s,%s,res.getDisplayMetrics()))"
                 , unit, dim);
     }


### PR DESCRIPTION
当XML设置padding/margin属性的值包含小数点时，生成的java类为：
cIndexBlock2.setPadding((int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5,res.getDisplayMetrics())),(int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5,res.getDisplayMetrics())),(int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5,res.getDisplayMetrics())),(int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5,res.getDisplayMetrics())));
编译时会报错：
无法将double转换为float（cannot convert from double to float）

本次mr判断属性值包含小数点时，按照float类型传参：
cIndexBlock2.setPadding((int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5f,res.getDisplayMetrics())),(int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5f,res.getDisplayMetrics())),(int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5f,res.getDisplayMetrics())),(int)(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP,5.5f,res.getDisplayMetrics())));