### PR TITLE
解析根View不设置LayoutParams，执行inflate时再设置，避免运行时类型转换错误

### DIFF
--- a/x2c-apt/src/main/java/com/zhangyue/we/view/View.java
+++ b/x2c-apt/src/main/java/com/zhangyue/we/view/View.java
@@ -170,9 +170,8 @@ public class View implements ITranslator {
             stringBuilder.append(String.format("%s %s = new %s(%s,%s);\n", paramsName, mLayoutParamsObj
                     , paramsName, width, height));
         } else {
-            String paramsName = getLayoutParams();
-            stringBuilder.append(String.format("%s %s = new %s(%s,%s);\n", paramsName, mLayoutParamsObj
-                    , paramsName, width, height));
+            stringBuilder.append(String.format("%s.setTag(R.id.x2c_rootview_width,%s);\n", obj, width));
+            stringBuilder.append(String.format("%s.setTag(R.id.x2c_rootview_height,%s);\n", obj, height));
         }
 
         ArrayList<ITranslator> translators = createTranslator();
@@ -210,8 +209,6 @@ public class View implements ITranslator {
         if (mParent != null) {
             stringBuilder.append(String.format("%s.setLayoutParams(%s);\n", obj, mLayoutParamsObj));
             stringBuilder.append(String.format("%s.addView(%s);\n", mParent.getObjName(), obj));
-        } else {
-            stringBuilder.append(String.format("%s.setLayoutParams(%s);\n", obj, mLayoutParamsObj));
         }
 
         if (!mPadding.equals("0")) {

--- a/x2c-lib/src/main/java/com/zhangyue/we/x2c/X2C.java
+++ b/x2c-lib/src/main/java/com/zhangyue/we/x2c/X2C.java
@@ -54,7 +54,13 @@ public final class X2C {
         View view = getView(inflater.getContext(), layoutId);
         if (view != null) {
             if (parent != null && attach) {
-                parent.addView(view);
+                Object width = view.getTag(R.id.x2c_rootview_width);
+                Object height = view.getTag(R.id.x2c_rootview_height);
+                if (width instanceof Integer && height instanceof Integer) {
+                    parent.addView(view, (int) width, (int) height);
+                } else {
+                    parent.addView(view);
+                }
             }
             return view;
         } else {

--- a/x2c-lib/src/main/res/values/ids.xml
+++ b/x2c-lib/src/main/res/values/ids.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <item type="id" name="x2c_rootview_width"/>
+    <item type="id" name="x2c_rootview_height"/>
+
+</resources>


### PR DESCRIPTION
在实际运行中，发生过crash，堆栈如下：
android.widget.LinearLayout$LayoutParams cannot be cast to android.widget.AbsListView$LayoutParams
        at android.widget.ListView.removeUnusedFixedViews(ListView.java:2038)
        at android.widget.ListView.trackMotionScroll(ListView.java:2021)
        at android.widget.AbsListView.scrollIfNeeded(AbsListView.java:3699)
        at android.widget.AbsListView.startScrollIfNeeded(AbsListView.java:3627)
        at android.widget.AbsListView.onInterceptTouchEvent(AbsListView.java:4644)
        at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2635)

这是一个列表的itemView，设置了LayoutParams为LinearLayout$LayoutParams，最终在获取LayoutParams时，发生了异常。

原因：在translate阶段设置根View的layoutParams是不准确的，因为parent没设置，所以不知道layoutParam的类型。

解决：在translate阶段，把根View的width和height保存在tag里，在inflate的时候再设置layoutParam。